### PR TITLE
Add JWT auth and API response wrapper

### DIFF
--- a/Apimaf.sln
+++ b/Apimaf.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apimaf.Domain", "src/Apimaf.Domain/Apimaf.Domain.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apimaf.Application", "src/Apimaf.Application/Apimaf.Application.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apimaf.Infrastructure", "src/Apimaf.Infrastructure/Apimaf.Infrastructure.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apimaf.WebAPI", "src/Apimaf.WebAPI/Apimaf.WebAPI.csproj", "{44444444-4444-4444-4444-444444444444}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apimaf.WebAPI.Tests", "tests/Apimaf.WebAPI.Tests/Apimaf.WebAPI.Tests.csproj", "{55555555-5555-5555-5555-555555555555}"
+EndProject
+Global
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# apimaf
-api maf
+# API REST Concesionarios
+
+Este proyecto contiene una estructura de ejemplo para crear una API REST "full" con **.NET 8** siguiendo una arquitectura exagonal. Se usan las siguientes entidades:
+
+- **Concesionario**
+- **Sucursal** (pertenece a un concesionario)
+
+La API expone operaciones CRUD y está preparada para integrarse con **Swagger**.
+
+## Estructura de carpetas
+
+```
+src/
+  Apimaf.Domain/          # Entidades y contratos de dominio
+  Apimaf.Application/     # DTOs y servicios de aplicación
+  Apimaf.Infrastructure/  # Implementaciones (EF Core, repositorios)
+  Apimaf.WebAPI/          # Proyecto Web API
+  tests/                  # Pruebas automatizadas
+```
+
+## Pasos para ejecutar
+
+1. Instalar el SDK de **.NET 8**.
+2. Restaurar dependencias y compilar:
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+3. Revisar `src/Apimaf.WebAPI/appsettings.json` y ajustar la cadena de conexión si es necesario. Por defecto se usa un SQL Server en Azure.
+4. Aplicar migraciones de Entity Framework Core (opcional según configuración):
+   ```bash
+   dotnet ef migrations add InitialCreate -p src/Apimaf.Infrastructure -s src/Apimaf.WebAPI
+   dotnet ef database update -p src/Apimaf.Infrastructure -s src/Apimaf.WebAPI
+   ```
+5. Ejecutar la API:
+   ```bash
+   dotnet run --project src/Apimaf.WebAPI
+   ```
+6. Abrir `https://localhost:{puerto}/swagger` para ver la documentación generada por Swagger.
+7. Para usar los endpoints protegidos, solicite primero un token JWT enviando un POST a `/login` con un cuerpo JSON `{ "username": "demo", "password": "demo" }`. El token devuelto deberá incluirse en la cabecera `Authorization: Bearer {token}`.
+8. Ejecutar las pruebas (opcional):
+   ```bash
+   dotnet test
+   ```
+
+## Descripción rápida
+
+La arquitectura se divide en varias capas:
+
+- **Dominio**: define las entidades `Concesionario` y `Sucursal`, además de las interfaces de repositorio.
+- **Aplicación**: contiene los servicios que orquestan la lógica de negocio y exponen DTOs.
+- **Infraestructura**: implementa los repositorios usando Entity Framework Core y define el `DbContext`.
+- **WebAPI**: configura los controladores, la inyección de dependencias y Swagger.
+
+Cada método posee comentarios `TODO` indicando su propósito principal.

--- a/src/Apimaf.Application/Apimaf.Application.csproj
+++ b/src/Apimaf.Application/Apimaf.Application.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Apimaf.Domain/Apimaf.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Apimaf.Application/DTOs/ConcesionarioDto.cs
+++ b/src/Apimaf.Application/DTOs/ConcesionarioDto.cs
@@ -1,0 +1,6 @@
+namespace Apimaf.Application.DTOs;
+
+/// <summary>
+/// DTO para exponer datos de la Concesionario.
+/// </summary>
+public record ConcesionarioDto(int Id, int Cod, string NomComercial, string Nombre);

--- a/src/Apimaf.Application/DTOs/SucursalDto.cs
+++ b/src/Apimaf.Application/DTOs/SucursalDto.cs
@@ -1,0 +1,6 @@
+namespace Apimaf.Application.DTOs;
+
+/// <summary>
+/// DTO para exponer datos de la Sucursal.
+/// </summary>
+public record SucursalDto(int Id, int IdConcesionario, string NomComercial);

--- a/src/Apimaf.Application/Services/ConcesionarioService.cs
+++ b/src/Apimaf.Application/Services/ConcesionarioService.cs
@@ -1,0 +1,39 @@
+using Apimaf.Application.DTOs;
+using Apimaf.Domain.Entities;
+using Apimaf.Domain.Interfaces;
+
+namespace Apimaf.Application.Services;
+
+/// <summary>
+/// Servicio de aplicación para manejar concesionarios.
+/// </summary>
+public class ConcesionarioService
+{
+    private readonly IConcesionarioRepository _repository;
+
+    public ConcesionarioService(IConcesionarioRepository repository)
+    {
+        _repository = repository;
+    }
+
+    // TODO: Devuelve todos los concesionarios como DTOs
+    public async Task<IEnumerable<ConcesionarioDto>> GetAllAsync()
+    {
+        var items = await _repository.GetAllAsync();
+        return items.Select(c => new ConcesionarioDto(c.Id, c.Cod, c.NomComercial, c.Nombre));
+    }
+
+    // TODO: Crea un nuevo concesionario
+    public async Task<int> CreateAsync(ConcesionarioDto dto)
+    {
+        var entity = new Concesionario
+        {
+            Cod = dto.Cod,
+            NomComercial = dto.NomComercial,
+            Nombre = dto.Nombre
+        };
+        await _repository.AddAsync(entity);
+        await _repository.SaveChangesAsync();
+        return entity.Id;
+    }
+}

--- a/src/Apimaf.Application/Services/SucursalService.cs
+++ b/src/Apimaf.Application/Services/SucursalService.cs
@@ -1,0 +1,38 @@
+using Apimaf.Application.DTOs;
+using Apimaf.Domain.Entities;
+using Apimaf.Domain.Interfaces;
+
+namespace Apimaf.Application.Services;
+
+/// <summary>
+/// Servicio de aplicación para manejar sucursales.
+/// </summary>
+public class SucursalService
+{
+    private readonly ISucursalRepository _repository;
+
+    public SucursalService(ISucursalRepository repository)
+    {
+        _repository = repository;
+    }
+
+    // TODO: Obtiene las sucursales por concesionario
+    public async Task<IEnumerable<SucursalDto>> GetByConcesionarioIdAsync(int concesionarioId)
+    {
+        var items = await _repository.GetByConcesionarioIdAsync(concesionarioId);
+        return items.Select(s => new SucursalDto(s.Id, s.IdConcesionario, s.NomComercial));
+    }
+
+    // TODO: Crea una nueva sucursal
+    public async Task<int> CreateAsync(SucursalDto dto)
+    {
+        var entity = new Sucursal
+        {
+            IdConcesionario = dto.IdConcesionario,
+            NomComercial = dto.NomComercial
+        };
+        await _repository.AddAsync(entity);
+        await _repository.SaveChangesAsync();
+        return entity.Id;
+    }
+}

--- a/src/Apimaf.Domain/Apimaf.Domain.csproj
+++ b/src/Apimaf.Domain/Apimaf.Domain.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/Apimaf.Domain/Entities/Concesionario.cs
+++ b/src/Apimaf.Domain/Entities/Concesionario.cs
@@ -1,0 +1,19 @@
+namespace Apimaf.Domain.Entities;
+
+/// <summary>
+/// Entidad principal de un concesionario de autos.
+/// </summary>
+public class Concesionario
+{
+    public int Id { get; set; }
+    public int Cod { get; set; }
+    public string NomComercial { get; set; } = string.Empty;
+    public string Nombre { get; set; } = string.Empty;
+    public string? Descripcion { get; set; }
+    public int FlgEstado { get; set; } = 1;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    // TODO: Lista de sucursales asociadas al concesionario
+    public ICollection<Sucursal> Sucursales { get; set; } = new List<Sucursal>();
+}

--- a/src/Apimaf.Domain/Entities/Sucursal.cs
+++ b/src/Apimaf.Domain/Entities/Sucursal.cs
@@ -1,0 +1,17 @@
+namespace Apimaf.Domain.Entities;
+
+/// <summary>
+/// Representa una sucursal del concesionario.
+/// </summary>
+public class Sucursal
+{
+    public int Id { get; set; }
+    public int IdConcesionario { get; set; }
+    public string NomComercial { get; set; } = string.Empty;
+    public int FlgEstado { get; set; } = 1;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    // TODO: Propiedad de navegación al Concesionario
+    public Concesionario? Concesionario { get; set; }
+}

--- a/src/Apimaf.Domain/Interfaces/IConcesionarioRepository.cs
+++ b/src/Apimaf.Domain/Interfaces/IConcesionarioRepository.cs
@@ -1,0 +1,21 @@
+using Apimaf.Domain.Entities;
+
+namespace Apimaf.Domain.Interfaces;
+
+/// <summary>
+/// Contrato para manejar los concesionarios.
+/// </summary>
+public interface IConcesionarioRepository
+{
+    // TODO: Devuelve todos los concesionarios
+    Task<IEnumerable<Concesionario>> GetAllAsync();
+
+    // TODO: Busca un concesionario por id
+    Task<Concesionario?> GetByIdAsync(int id);
+
+    // TODO: Crea un nuevo concesionario
+    Task AddAsync(Concesionario entity);
+
+    // TODO: Guarda los cambios
+    Task SaveChangesAsync();
+}

--- a/src/Apimaf.Domain/Interfaces/ISucursalRepository.cs
+++ b/src/Apimaf.Domain/Interfaces/ISucursalRepository.cs
@@ -1,0 +1,18 @@
+using Apimaf.Domain.Entities;
+
+namespace Apimaf.Domain.Interfaces;
+
+/// <summary>
+/// Contrato para manejar las sucursales.
+/// </summary>
+public interface ISucursalRepository
+{
+    // TODO: Obtiene todas las sucursales de un concesionario
+    Task<IEnumerable<Sucursal>> GetByConcesionarioIdAsync(int concesionarioId);
+
+    // TODO: Crea una nueva sucursal
+    Task AddAsync(Sucursal entity);
+
+    // TODO: Guarda los cambios
+    Task SaveChangesAsync();
+}

--- a/src/Apimaf.Infrastructure/Apimaf.Infrastructure.csproj
+++ b/src/Apimaf.Infrastructure/Apimaf.Infrastructure.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Apimaf.Domain/Apimaf.Domain.csproj" />
+    <ProjectReference Include="../Apimaf.Application/Apimaf.Application.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Apimaf.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Apimaf.Infrastructure/Data/ApplicationDbContext.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Apimaf.Domain.Entities;
+
+namespace Apimaf.Infrastructure.Data;
+
+/// <summary>
+/// DbContext de la aplicación.
+/// </summary>
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    // TODO: Tabla de Concesionarios
+    public DbSet<Concesionario> Concesionarios => Set<Concesionario>();
+    // TODO: Tabla de Sucursales
+    public DbSet<Sucursal> Sucursales => Set<Sucursal>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // TODO: Configurar tablas y relación uno a muchos
+        modelBuilder.Entity<Concesionario>(entity =>
+        {
+            entity.ToTable("concesionario");
+
+            // Mapeo explícito de columnas para coincidir con la base de datos
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Cod).HasColumnName("cod");
+            entity.Property(e => e.NomComercial).HasColumnName("nom_comercial");
+            entity.Property(e => e.Nombre).HasColumnName("nombre");
+            entity.Property(e => e.Descripcion).HasColumnName("descripcion");
+            entity.Property(e => e.FlgEstado).HasColumnName("flg_estado");
+            entity.Property(e => e.CreatedAt).HasColumnName("created_at");
+            entity.Property(e => e.UpdatedAt).HasColumnName("updated_at");
+
+            entity.HasMany(c => c.Sucursales)
+                  .WithOne(s => s.Concesionario!)
+                  .HasForeignKey(s => s.IdConcesionario);
+        });
+
+        modelBuilder.Entity<Sucursal>(entity =>
+        {
+            entity.ToTable("sucursal");
+
+            // Mapeo explícito de columnas
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.IdConcesionario).HasColumnName("id_concesionario");
+            entity.Property(e => e.NomComercial).HasColumnName("nom_comercial");
+            entity.Property(e => e.FlgEstado).HasColumnName("flg_estado");
+            entity.Property(e => e.CreatedAt).HasColumnName("created_at");
+            entity.Property(e => e.UpdatedAt).HasColumnName("updated_at");
+        });
+    }
+}

--- a/src/Apimaf.Infrastructure/Repositories/ConcesionarioRepository.cs
+++ b/src/Apimaf.Infrastructure/Repositories/ConcesionarioRepository.cs
@@ -1,0 +1,35 @@
+using Apimaf.Domain.Entities;
+using Apimaf.Domain.Interfaces;
+using Apimaf.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Apimaf.Infrastructure.Repositories;
+
+/// <summary>
+/// Implementación de repositorio de concesionarios usando EF Core.
+/// </summary>
+public class ConcesionarioRepository : IConcesionarioRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public ConcesionarioRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    // TODO: Devuelve todos los concesionarios
+    public async Task<IEnumerable<Concesionario>> GetAllAsync()
+        => await _context.Concesionarios.AsNoTracking().ToListAsync();
+
+    // TODO: Busca un concesionario por id
+    public async Task<Concesionario?> GetByIdAsync(int id)
+        => await _context.Concesionarios.FindAsync(id);
+
+    // TODO: Crea un nuevo concesionario
+    public async Task AddAsync(Concesionario entity)
+        => await _context.Concesionarios.AddAsync(entity);
+
+    // TODO: Guarda los cambios
+    public async Task SaveChangesAsync()
+        => await _context.SaveChangesAsync();
+}

--- a/src/Apimaf.Infrastructure/Repositories/SucursalRepository.cs
+++ b/src/Apimaf.Infrastructure/Repositories/SucursalRepository.cs
@@ -1,0 +1,31 @@
+using Apimaf.Domain.Entities;
+using Apimaf.Domain.Interfaces;
+using Apimaf.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Apimaf.Infrastructure.Repositories;
+
+/// <summary>
+/// Implementación de repositorio de sucursales usando EF Core.
+/// </summary>
+public class SucursalRepository : ISucursalRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public SucursalRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    // TODO: Obtiene todas las sucursales de un concesionario
+    public async Task<IEnumerable<Sucursal>> GetByConcesionarioIdAsync(int concesionarioId)
+        => await _context.Sucursales.Where(s => s.IdConcesionario == concesionarioId).ToListAsync();
+
+    // TODO: Crea una nueva sucursal
+    public async Task AddAsync(Sucursal entity)
+        => await _context.Sucursales.AddAsync(entity);
+
+    // TODO: Guarda los cambios
+    public async Task SaveChangesAsync()
+        => await _context.SaveChangesAsync();
+}

--- a/src/Apimaf.WebAPI/ApiResponse.cs
+++ b/src/Apimaf.WebAPI/ApiResponse.cs
@@ -1,0 +1,7 @@
+namespace Apimaf.WebAPI;
+
+/// <summary>
+/// Contenedor estándar para las respuestas de la API.
+/// </summary>
+/// <typeparam name="T">Tipo de la propiedad Data.</typeparam>
+public record ApiResponse<T>(int ErrorCode, string Message, T? Data);

--- a/src/Apimaf.WebAPI/Apimaf.WebAPI.csproj
+++ b/src/Apimaf.WebAPI/Apimaf.WebAPI.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Apimaf.Application/Apimaf.Application.csproj" />
+    <ProjectReference Include="../Apimaf.Infrastructure/Apimaf.Infrastructure.csproj" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Apimaf.WebAPI/ErrorHandlingMiddleware.cs
+++ b/src/Apimaf.WebAPI/ErrorHandlingMiddleware.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using System.Text.Json;
+
+namespace Apimaf.WebAPI;
+
+/// <summary>
+/// Middleware para capturar excepciones y devolver un formato de error coherente.
+/// </summary>
+public class ErrorHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ErrorHandlingMiddleware> _logger;
+
+    public ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            context.Response.ContentType = "application/json";
+            var response = new ApiResponse<object>(5000, "Unexpected error", null);
+            await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+        }
+    }
+}

--- a/src/Apimaf.WebAPI/LoginDto.cs
+++ b/src/Apimaf.WebAPI/LoginDto.cs
@@ -1,0 +1,3 @@
+namespace Apimaf.WebAPI;
+
+public record LoginDto(string Username, string Password);

--- a/src/Apimaf.WebAPI/Program.cs
+++ b/src/Apimaf.WebAPI/Program.cs
@@ -1,0 +1,94 @@
+using Apimaf.Application.Services;
+using Apimaf.Application.DTOs;
+using Apimaf.Domain.Interfaces;
+using Apimaf.Infrastructure.Data;
+using Apimaf.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Apimaf.WebAPI;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// TODO: Configurar cadena de conexión (valor por defecto en appsettings)
+var connectionString = builder.Configuration.GetConnectionString("Default") ?? string.Empty;
+
+// TODO: Registrar DbContext y servicios
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddScoped<ConcesionarioService>();
+builder.Services.AddScoped<SucursalService>();
+
+builder.Services.AddScoped<IConcesionarioRepository, ConcesionarioRepository>();
+builder.Services.AddScoped<ISucursalRepository, SucursalRepository>();
+
+// TODO: Configurar Swagger
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// TODO: Configurar autenticación JWT
+var jwtSection = builder.Configuration.GetSection("Jwt");
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwtSection["Issuer"],
+            ValidAudience = jwtSection["Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSection["Key"] ?? string.Empty))
+        };
+    });
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+// Middleware de manejo de errores
+app.UseMiddleware<ErrorHandlingMiddleware>();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+// TODO: Endpoint para obtener un token JWT (ficticio)
+app.MapPost("/login", (LoginDto login) =>
+{
+    var claims = new[] { new Claim(ClaimTypes.Name, login.Username) };
+    var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSection["Key"]!));
+    var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+    var token = new JwtSecurityToken(
+        issuer: jwtSection["Issuer"],
+        audience: jwtSection["Audience"],
+        claims: claims,
+        expires: DateTime.UtcNow.AddHours(1),
+        signingCredentials: creds);
+    var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
+    return Results.Ok(new ApiResponse<string>(0, "OK", tokenString));
+});
+
+// TODO: Mapear endpoints de concesionarios
+app.MapGet("/concesionarios", async (ConcesionarioService service) =>
+{
+    var data = await service.GetAllAsync();
+    return Results.Ok(new ApiResponse<IEnumerable<ConcesionarioDto>>(0, "OK", data));
+}).RequireAuthorization();
+
+// TODO: Mapear endpoints de sucursales
+app.MapGet("/concesionarios/{id}/sucursales", async (int id, SucursalService service) =>
+{
+    var data = await service.GetByConcesionarioIdAsync(id);
+    return Results.Ok(new ApiResponse<IEnumerable<SucursalDto>>(0, "OK", data));
+}).RequireAuthorization();
+
+app.Run();
+
+public partial class Program { }

--- a/src/Apimaf.WebAPI/appsettings.json
+++ b/src/Apimaf.WebAPI/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "ConnectionStrings": {
+    "Default": "Server=tcp:one-maf-bd.database.windows.net,1433;Initial Catalog=one_maf;Persist Security Info=False;User ID=one-maf-user;Password=4dm1n-bd2025;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKeyChangeMe",
+    "Issuer": "Apimaf",
+    "Audience": "ApimafUsers"
+  }
+}

--- a/tests/Apimaf.WebAPI.Tests/Apimaf.WebAPI.Tests.csproj
+++ b/tests/Apimaf.WebAPI.Tests/Apimaf.WebAPI.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Apimaf.WebAPI/Apimaf.WebAPI.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Apimaf.WebAPI.Tests/CustomWebApplicationFactory.cs
+++ b/tests/Apimaf.WebAPI.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,50 @@
+using Apimaf.Infrastructure.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Apimaf.WebAPI.Tests;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Remove existing DbContext registration
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            // Add in-memory database for tests
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseInMemoryDatabase("TestDb"));
+
+            // Build service provider
+            var sp = services.BuildServiceProvider();
+
+            // Create a scope to seed data
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureCreated();
+
+            // Seed initial data
+            var concesionario = new Apimaf.Domain.Entities.Concesionario
+            {
+                Cod = 1,
+                NomComercial = "Test Dealer",
+                Nombre = "Dealer 1"
+            };
+            db.Concesionarios.Add(concesionario);
+            db.Sucursales.Add(new Apimaf.Domain.Entities.Sucursal
+            {
+                IdConcesionario = concesionario.Id,
+                NomComercial = "Main Branch"
+            });
+            db.SaveChanges();
+        });
+    }
+}

--- a/tests/Apimaf.WebAPI.Tests/EndpointTests.cs
+++ b/tests/Apimaf.WebAPI.Tests/EndpointTests.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Http.Json;
+using Apimaf.WebAPI;
+using Xunit;
+
+namespace Apimaf.WebAPI.Tests;
+
+public class EndpointTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public EndpointTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+        // Obtener token JWT de pruebas
+        var tokenResponse = _client.PostAsJsonAsync("/login", new { username = "demo", password = "demo" }).Result;
+        var token = tokenResponse.Content.ReadFromJsonAsync<ApiResponse<string>>().Result?.Data;
+        if (!string.IsNullOrEmpty(token))
+        {
+            _client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+
+    [Fact]
+    public async Task GetConcesionarios_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/concesionarios");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var wrapper = await response.Content.ReadFromJsonAsync<ApiResponse<List<object>>>();
+        Assert.NotNull(wrapper);
+        Assert.NotNull(wrapper!.Data);
+        Assert.NotEmpty(wrapper.Data!);
+    }
+
+    [Fact]
+    public async Task GetSucursales_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/concesionarios/1/sucursales");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var wrapper = await response.Content.ReadFromJsonAsync<ApiResponse<List<object>>>();
+        Assert.NotNull(wrapper);
+        Assert.NotNull(wrapper!.Data);
+        Assert.NotEmpty(wrapper.Data!);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ApiResponse` type and error handling middleware
- configure JWT authentication and protect endpoints
- expose `/login` endpoint to generate tokens
- wrap responses in `ApiResponse` objects
- document JWT usage in README
- update tests to authenticate and read wrapped data

## Testing
- `dotnet build Apimaf.sln` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852af7130f08324a3b8f5f8dbe04280